### PR TITLE
use regular bitcore-build

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,5 +1,5 @@
 
 
-var bitcoreTasks = require('bitcore-build-zcash');
+var bitcoreTasks = require('bitcore-build');
 
-bitcoreTasks('lib');
+bitcoreTasks('lib-zcash');

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "lodash": "=3.10.1"
   },
   "devDependencies": {
-    "bitcore-build-zcash": "str4d/bitcore-build-zcash",
+    "bitcore-build": "bitpay/bitcore-build",
     "brfs": "^1.2.0",
     "chai": "^1.10.0",
     "gulp": "^3.8.10",


### PR DESCRIPTION
The current version of str4d/bitcore-build-zcash doesn't support newer versions of npm. I think we can use the regular bitpay/bitcore-build as they support a `name` argument. This seems to work with newer versions of node.